### PR TITLE
Make getting ancestors optional

### DIFF
--- a/ontorunner/oger_module.py
+++ b/ontorunner/oger_module.py
@@ -16,6 +16,7 @@ def run_oger(
     settings="settings.ini",
     workers=1,
     nodes_and_edges=NODE_AND_EDGE_DIR,
+    need_ancestors=True,
 ) -> None:
     """
     Run Oger
@@ -67,7 +68,7 @@ def run_oger(
             input = os.path.dirname(content)
             output = os.path.dirname(output)
 
-    add_sentence.parse(input, output, nodes_and_edges)
+    add_sentence.parse(input, output, nodes_and_edges, need_ancestors)
 
     # os.system('say "Done!"')
 
@@ -92,6 +93,7 @@ def cli():
     type=click.Path(exists=True),
     default=NODE_AND_EDGE_DIR,
 )
+@click.option("--need-ancestors", "-a", type=bool, default=True)
 def run_oger_click(
     content,
     termlist,
@@ -100,6 +102,7 @@ def run_oger_click(
     settings,
     workers,
     nodes_and_edges,
+    need_ancestors,
 ):
     run_oger(
         content,
@@ -109,6 +112,7 @@ def run_oger_click(
         settings,
         workers,
         nodes_and_edges,
+        need_ancestors,
     )
 
 

--- a/ontorunner/post/add_sentence.py
+++ b/ontorunner/post/add_sentence.py
@@ -214,7 +214,12 @@ def get_match_type(token1: str, token2: str) -> str:
     return match
 
 
-def parse(input_directory, output_directory, nodes_and_edges) -> None:
+def parse(
+    input_directory: str,
+    output_directory: str,
+    nodes_and_edges: str,
+    need_ancestors: bool,
+) -> None:
     """
     This parses the OGER output and adds sentences of relevant tokenized terms
     for context to the reviewer.
@@ -345,7 +350,8 @@ def parse(input_directory, output_directory, nodes_and_edges) -> None:
             ]
         )
         # TODO: Maybe use OAK for getting ancestors (?)
-        output_df = get_ancestors(output_df, nodes_and_edges)
+        if need_ancestors:
+            output_df = get_ancestors(output_df, nodes_and_edges)
 
         final_output_file = output_file.replace(".tsv", "_ontoRunNER.tsv")
 

--- a/ontorunner/spacy_module.py
+++ b/ontorunner/spacy_module.py
@@ -12,7 +12,7 @@ from glob import glob
 import pandas as pd
 from spacy.tokens import Span
 from multiprocessing import freeze_support
-from ontorunner.post import util
+from ontorunner.post import NODE_AND_EDGE_NAME, util
 import click
 
 SCI_SPACY_LINKERS = ["umls", "mesh"]
@@ -270,7 +270,10 @@ def run_spacy(
     onto_df = util.get_column_doc_ratio(onto_df, "object_label")
     onto_df = util.get_column_doc_ratio(onto_df, "matched_term")
     if need_ancestors:
-        onto_df = util.get_ancestors(onto_df)
+        nodes_and_edges_dir = os.path.join(data_dir, NODE_AND_EDGE_NAME)
+        onto_df = util.get_ancestors(
+            df=onto_df, nodes_and_edges_dir=nodes_and_edges_dir
+        )
 
     onto_df = onto_df.astype(str).drop_duplicates()
     kb_df = kb_df.astype(str).drop_duplicates()

--- a/ontorunner/spacy_module.py
+++ b/ontorunner/spacy_module.py
@@ -207,6 +207,7 @@ def run_spacy(
     settings_file: Path = SETTINGS_FILE_PATH,
     linker: str = "umls",
     to_pickle: bool = True,
+    need_ancestors: bool = True,
 ):
     """
     Run spacy with sciSpacy pipeline.
@@ -268,7 +269,8 @@ def run_spacy(
     onto_df = util.consolidate_rows(onto_df)
     onto_df = util.get_column_doc_ratio(onto_df, "object_label")
     onto_df = util.get_column_doc_ratio(onto_df, "matched_term")
-    # onto_df = util.get_ancestors(onto_df)
+    if need_ancestors:
+        onto_df = util.get_ancestors(onto_df)
 
     onto_df = onto_df.astype(str).drop_duplicates()
     kb_df = kb_df.astype(str).drop_duplicates()
@@ -300,17 +302,20 @@ def run_spacy(
     help="Boolean to determine if intermediate files should be pickled or no",
     default=True,
 )
+@click.option("--need-ancestors", "-a", type=bool, default=True)
 def run_spacy_click(
     data_dir: Path,
     settings_file: Path,
     linker: str,
     pickle_files: bool,
+    need_ancestors: bool,
 ):
     run_spacy(
         data_dir=data_dir,
         settings_file=settings_file,
         linker=linker,
         to_pickle=pickle_files,
+        need_ancestors=need_ancestors,
     )
 
     # os.system('say "Done!"')


### PR DESCRIPTION
This gives the user an option of requesting ancestors of annotated terms or not by using `-a` or `--need-ancestors` which is a `bool` parameter and it defaults to `True`